### PR TITLE
fix: Increase size of MySql datalength for Message to TEXT and AllXML

### DIFF
--- a/ElmahCore.MySql/CommandExtension.cs
+++ b/ElmahCore.MySql/CommandExtension.cs
@@ -35,12 +35,12 @@ namespace ElmahCore.MySql
                 Host 		VARCHAR(50) NOT NULL,
                 Type		VARCHAR(100) NOT NULL,
                 Source		VARCHAR(60)  NOT NULL,
-                Message		VARCHAR(500) NOT NULL,
+                Message		TEXT NOT NULL,
                 User		VARCHAR(50)  NOT NULL,
                 StatusCode	INT NOT NULL,
                 TimeUtc		TIMESTAMP NOT NULL,
                 Sequence	INT NOT NULL AUTO_INCREMENT,
-                AllXml		TEXT NOT NULL,
+                AllXml		MEDIUMTEXT NOT NULL,
                 KEY(Sequence)
             );
 


### PR DESCRIPTION
The exception detail in Microsoft.Graph.ServiceException can easily outgrow the existing sizes of the Message and AllXml columns. To allow these to be recorded, I've expanded the column sizes:

Message increased from VARCHAR(500) to TEXT, which can hold 64kB
AllXml increased from TEXT to MEDIUMTEXT, which can hold 16MB


From https://github.com/ElmahCore/ElmahCore/pull/169
Original author @RaceProUK