### PR TITLE
feat: Add configurable LogAllXml option to disable full XML logging

### DIFF
--- a/ElmahCore.MsSql/SqlErrorLog.cs
+++ b/ElmahCore.MsSql/SqlErrorLog.cs
@@ -14,6 +14,7 @@ namespace ElmahCore.Sql;
 public class SqlErrorLog : ErrorLog
 {
     private const int MaxAppNameLength = 60;
+    private readonly bool _logAllXml;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="SqlErrorLog" /> class
@@ -21,7 +22,8 @@ public class SqlErrorLog : ErrorLog
     /// </summary>
     public SqlErrorLog(IOptions<ElmahOptions> option)
         : this(option.Value.ConnectionString, option.Value.SqlServerDatabaseSchemaName,
-            option.Value.SqlServerDatabaseTableName, option.Value.CreateTablesIfNotExist)
+            option.Value.SqlServerDatabaseTableName, option.Value.CreateTablesIfNotExist,
+            option.Value.LogAllXml)
     {
     }
 
@@ -30,7 +32,7 @@ public class SqlErrorLog : ErrorLog
     ///     to use a specific connection string for connecting to the database and a specific schema and table name.
     /// </summary>
     public SqlErrorLog(string connectionString, string schemaName = null, string tableName = null,
-        bool createTablesIfNotExist = true)
+        bool createTablesIfNotExist = true, bool logAllXml = true)
     {
         if (string.IsNullOrEmpty(connectionString))
             throw new ArgumentNullException(nameof(connectionString));
@@ -38,6 +40,7 @@ public class SqlErrorLog : ErrorLog
         ConnectionString = connectionString;
         DatabaseSchemaName = !string.IsNullOrWhiteSpace(schemaName) ? schemaName : "dbo";
         DatabaseTableName = !string.IsNullOrWhiteSpace(tableName) ? tableName : "ELMAH_Error";
+        _logAllXml = logAllXml;
 
         if (createTablesIfNotExist)
             CreateTableIfNotExists();
@@ -75,7 +78,9 @@ public class SqlErrorLog : ErrorLog
     {
         try
         {
-            var errorXml = ErrorXml.EncodeString(error);
+            var errorXml = _logAllXml
+                ? ErrorXml.EncodeString(error)
+                : "<error message=\"AllXml logging disabled\" />";
 
             using var connection = new SqlConnection(ConnectionString);
             using var command = Commands.LogError(id, ApplicationName, error.HostName, error.Type, error.Source,

--- a/ElmahCore.MsSql/SqlErrorLog.cs
+++ b/ElmahCore.MsSql/SqlErrorLog.cs
@@ -98,7 +98,7 @@ public class SqlErrorLog : ErrorLog
 
     public override ErrorLogEntry GetError(string id)
     {
-        if (id == null) throw new ArgumentNullException(nameof(id));
+        ArgumentNullException.ThrowIfNull(id);
         if (id.Length == 0) throw new ArgumentException(null, nameof(id));
 
         Guid errorGuid;
@@ -253,7 +253,6 @@ WHERE EXISTS (
 "
             };
         }
-
 
         public static SqlCommand LogError(
             Guid id,

--- a/ElmahCore.MySql/MySqlErrorLog.cs
+++ b/ElmahCore.MySql/MySqlErrorLog.cs
@@ -98,7 +98,7 @@ public class MySqlErrorLog : ErrorLog
         {
             command.Connection = connection;
             connection.Open();
-            errorXml = (string) command.ExecuteScalar();
+            errorXml = (string)command.ExecuteScalar();
         }
 
         if (errorXml == null)

--- a/ElmahCore.MySql/MySqlErrorLog.cs
+++ b/ElmahCore.MySql/MySqlErrorLog.cs
@@ -13,11 +13,14 @@ namespace ElmahCore.MySql;
 [UsedImplicitly]
 public class MySqlErrorLog : ErrorLog
 {
+    private readonly bool _logAllXml;
+
     /// <summary>
     ///     Initializes a new instance of the <see cref="MySqlErrorLog" /> class
     ///     using a dictionary of configured settings.
     /// </summary>
-    public MySqlErrorLog(IOptions<ElmahOptions> option) : this(option.Value.ConnectionString)
+    public MySqlErrorLog(IOptions<ElmahOptions> option) : this(option.Value.ConnectionString,
+        option.Value.CreateTablesIfNotExist, option.Value.LogAllXml)
     {
     }
 
@@ -25,13 +28,16 @@ public class MySqlErrorLog : ErrorLog
     ///     Initializes a new instance of the <see cref="MySqlErrorLog" /> class
     ///     to use a specific connection string for connecting to the database.
     /// </summary>
-    public MySqlErrorLog(string connectionString)
+    public MySqlErrorLog(string connectionString, bool createTablesIfNotExist = true, bool logAllXml = true)
     {
         if (string.IsNullOrEmpty(connectionString))
             throw new ArgumentNullException(nameof(connectionString));
 
         ConnectionString = connectionString;
-        CreateTableIfNotExist();
+        _logAllXml = logAllXml;
+
+        if (createTablesIfNotExist)
+            CreateTableIfNotExist();
     }
 
     /// <summary>
@@ -57,7 +63,9 @@ public class MySqlErrorLog : ErrorLog
     {
         ArgumentNullException.ThrowIfNull(error);
 
-        var errorXml = ErrorXml.EncodeString(error);
+        var errorXml = _logAllXml
+            ? ErrorXml.EncodeString(error)
+            : "<error message=\"AllXml logging disabled\" />";
 
         using var connection = new MySqlConnection(ConnectionString);
         using var command = CommandExtension.LogError(id, ApplicationName, error.HostName, error.Type,

--- a/ElmahCore.Postgresql/PgsqlErrorLog.cs
+++ b/ElmahCore.Postgresql/PgsqlErrorLog.cs
@@ -100,7 +100,7 @@ public class PgsqlErrorLog : ErrorLog
         {
             command.Connection = connection;
             connection.Open();
-            errorXml = (string) command.ExecuteScalar();
+            errorXml = (string)command.ExecuteScalar();
         }
 
         if (errorXml == null)
@@ -152,7 +152,7 @@ public class PgsqlErrorLog : ErrorLog
         using var cmdCheck = Commands.CheckTable();
         cmdCheck.Connection = connection;
         // ReSharper disable once PossibleNullReferenceException
-        var exists = (bool) cmdCheck.ExecuteScalar();
+        var exists = (bool)cmdCheck.ExecuteScalar();
 
         if (exists) return;
         using var cmdCreate = Commands.CreateTable();

--- a/ElmahCore.Postgresql/PgsqlErrorLog.cs
+++ b/ElmahCore.Postgresql/PgsqlErrorLog.cs
@@ -79,7 +79,7 @@ public class PgsqlErrorLog : ErrorLog
 
     public override ErrorLogEntry GetError(string id)
     {
-        if (id == null) throw new ArgumentNullException(nameof(id));
+        ArgumentNullException.ThrowIfNull(id);
         if (id.Length == 0) throw new ArgumentException(null, nameof(id));
 
         Guid errorGuid;
@@ -159,7 +159,6 @@ public class PgsqlErrorLog : ErrorLog
         cmdCreate.Connection = connection;
         cmdCreate.ExecuteNonQuery();
     }
-
 
     private static class Commands
     {

--- a/ElmahCore.Postgresql/PgsqlErrorLog.cs
+++ b/ElmahCore.Postgresql/PgsqlErrorLog.cs
@@ -15,12 +15,14 @@ namespace ElmahCore.Postgresql;
 public class PgsqlErrorLog : ErrorLog
 {
     private const int MaxAppNameLength = 60;
+    private readonly bool _logAllXml;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="PgsqlErrorLog" /> class
     ///     using a dictionary of configured settings.
     /// </summary>
-    public PgsqlErrorLog(IOptions<ElmahOptions> option) : this(option.Value.ConnectionString, option.Value.CreateTablesIfNotExist)
+    public PgsqlErrorLog(IOptions<ElmahOptions> option) : this(option.Value.ConnectionString, option.Value.CreateTablesIfNotExist,
+        option.Value.LogAllXml)
     {
     }
 
@@ -28,12 +30,13 @@ public class PgsqlErrorLog : ErrorLog
     ///     Initializes a new instance of the <see cref="PgsqlErrorLog" /> class
     ///     to use a specific connection string for connecting to the database.
     /// </summary>
-    public PgsqlErrorLog(string connectionString, bool createTablesIfNotExist)
+    public PgsqlErrorLog(string connectionString, bool createTablesIfNotExist, bool logAllXml = true)
     {
         if (string.IsNullOrEmpty(connectionString))
             throw new ArgumentNullException(nameof(connectionString));
 
         ConnectionString = connectionString;
+        _logAllXml = logAllXml;
 
         if (createTablesIfNotExist)
             CreateTableIfNotExists();
@@ -62,7 +65,9 @@ public class PgsqlErrorLog : ErrorLog
     {
         ArgumentNullException.ThrowIfNull(error);
 
-        var errorXml = ErrorXml.EncodeString(error);
+        var errorXml = _logAllXml
+            ? ErrorXml.EncodeString(error)
+            : "<error message=\"AllXml logging disabled\" />";
 
         using var connection = new NpgsqlConnection(ConnectionString);
         using var command = Commands.LogError(id, ApplicationName, error.HostName, error.Type, error.Source,

--- a/ElmahCore.slnx
+++ b/ElmahCore.slnx
@@ -7,6 +7,7 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="Tests/ElmahCore.Mvc.Tests/ElmahCore.Mvc.Tests.csproj" />
+    <Project Path="Tests/ElmahCore.Tests/ElmahCore.Tests.csproj" />
   </Folder>
   <Project Path="ElmahCore.MsSql/ElmahCore.Sql.csproj" />
   <Project Path="ElmahCore.Mvc/ElmahCore.Mvc.csproj" />

--- a/ElmahCore/ElmahOptions.cs
+++ b/ElmahCore/ElmahOptions.cs
@@ -95,6 +95,13 @@ public class ElmahOptions
     /// </summary>
     public bool EnableDiagnosticObserver { get; set; } = true;
 
+    /// <summary>
+    ///     Enable/Disable storing the full XML representation of errors in the database.
+    ///     When disabled, a minimal placeholder is stored instead.
+    ///     Default is true for backward compatibility.
+    /// </summary>
+    public bool LogAllXml { get; set; } = true;
+
     public virtual bool PermissionCheck(HttpContext context)
     {
         return OnPermissionCheck(context);

--- a/README.md
+++ b/README.md
@@ -106,6 +106,20 @@ services.AddElmah<SqlErrorLog>(options =>
 });
 ```
 
+## Disable Full XML Logging
+
+For high-volume applications, you can disable storing the full XML representation of errors in the database to reduce storage requirements. When disabled, a minimal placeholder XML is stored instead. The basic error fields (type, message, source, user, time, statusCode) are still stored in dedicated database columns.
+
+```csharp
+services.AddElmah<SqlErrorLog>(options =>
+{
+  options.ConnectionString = "connection_string";
+  options.LogAllXml = false; // Disable full XML storage
+});
+```
+
+This option works with `SqlErrorLog`, `MySqlErrorLog`, and `PgsqlErrorLog`. Default is `true` for backward compatibility.
+
 ## Raise exception
 
 To raise a custom exception to log:

--- a/Tests/ElmahCore.Tests/ElmahCore.Tests.csproj
+++ b/Tests/ElmahCore.Tests/ElmahCore.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <LangVersion>default</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="8.8.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="NSubstitute" Version="5.3.0"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\ElmahCore\ElmahCore.csproj"/>
+        <ProjectReference Include="..\..\ElmahCore.MsSql\ElmahCore.Sql.csproj"/>
+        <ProjectReference Include="..\..\ElmahCore.MySql\ElmahCore.MySql.csproj"/>
+        <ProjectReference Include="..\..\ElmahCore.Postgresql\ElmahCore.Postgresql.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/Tests/ElmahCore.Tests/LogAllXmlTests.cs
+++ b/Tests/ElmahCore.Tests/LogAllXmlTests.cs
@@ -1,0 +1,28 @@
+using System;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace ElmahCore.Tests;
+
+public class LogAllXmlTests
+{
+    [Fact]
+    public void ElmahOptions_LogAllXml_DefaultsToTrue()
+    {
+        var options = new ElmahOptions();
+
+        options.LogAllXml.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ElmahOptions_LogAllXml_CanBeSetToFalse()
+    {
+        var options = new ElmahOptions();
+
+        options.LogAllXml = false;
+
+        options.LogAllXml.Should().BeFalse();
+    }
+}

--- a/Tests/ElmahCore.Tests/LogAllXmlTests.cs
+++ b/Tests/ElmahCore.Tests/LogAllXmlTests.cs
@@ -1,7 +1,4 @@
-using System;
 using FluentAssertions;
-using Microsoft.Extensions.Options;
-using NSubstitute;
 using Xunit;
 
 namespace ElmahCore.Tests;

--- a/Tests/ElmahCore.Tests/MySqlErrorLogTests.cs
+++ b/Tests/ElmahCore.Tests/MySqlErrorLogTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+using ElmahCore.MySql;
+
+namespace ElmahCore.Tests;
+
+public class MySqlErrorLogTests
+{
+    [Fact]
+    public void MySqlErrorLog_WithOptions_LogAllXmlTrue_DoesNotThrow()
+    {
+        var options = Substitute.For<IOptions<ElmahOptions>>();
+        options.Value.Returns(new ElmahOptions
+        {
+            ConnectionString = "Server=localhost;Database=test;",
+            LogAllXml = true,
+            CreateTablesIfNotExist = false
+        });
+
+        var act = () => new MySqlErrorLog(options);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void MySqlErrorLog_WithOptions_LogAllXmlFalse_DoesNotThrow()
+    {
+        var options = Substitute.For<IOptions<ElmahOptions>>();
+        options.Value.Returns(new ElmahOptions
+        {
+            ConnectionString = "Server=localhost;Database=test;",
+            LogAllXml = false,
+            CreateTablesIfNotExist = false
+        });
+
+        var act = () => new MySqlErrorLog(options);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void MySqlErrorLog_Constructor_WithLogAllXmlParameter_DoesNotThrow()
+    {
+        var act = () => new MySqlErrorLog(
+            connectionString: "Server=localhost;Database=test;",
+            createTablesIfNotExist: false,
+            logAllXml: false);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void MySqlErrorLog_Constructor_LogAllXmlDefaultsToTrue()
+    {
+        // The constructor has logAllXml = true as default parameter
+        var act = () => new MySqlErrorLog(
+            connectionString: "Server=localhost;Database=test;",
+            createTablesIfNotExist: false);
+
+        act.Should().NotThrow();
+    }
+}

--- a/Tests/ElmahCore.Tests/PgsqlErrorLogTests.cs
+++ b/Tests/ElmahCore.Tests/PgsqlErrorLogTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+using ElmahCore.Postgresql;
+
+namespace ElmahCore.Tests;
+
+public class PgsqlErrorLogTests
+{
+    [Fact]
+    public void PgsqlErrorLog_WithOptions_LogAllXmlTrue_DoesNotThrow()
+    {
+        var options = Substitute.For<IOptions<ElmahOptions>>();
+        options.Value.Returns(new ElmahOptions
+        {
+            ConnectionString = "Host=localhost;Database=test;",
+            LogAllXml = true,
+            CreateTablesIfNotExist = false
+        });
+
+        var act = () => new PgsqlErrorLog(options);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void PgsqlErrorLog_WithOptions_LogAllXmlFalse_DoesNotThrow()
+    {
+        var options = Substitute.For<IOptions<ElmahOptions>>();
+        options.Value.Returns(new ElmahOptions
+        {
+            ConnectionString = "Host=localhost;Database=test;",
+            LogAllXml = false,
+            CreateTablesIfNotExist = false
+        });
+
+        var act = () => new PgsqlErrorLog(options);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void PgsqlErrorLog_Constructor_WithLogAllXmlParameter_DoesNotThrow()
+    {
+        var act = () => new PgsqlErrorLog(
+            connectionString: "Host=localhost;Database=test;",
+            createTablesIfNotExist: false,
+            logAllXml: false);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void PgsqlErrorLog_Constructor_LogAllXmlDefaultsToTrue()
+    {
+        // The constructor has logAllXml = true as default parameter
+        var act = () => new PgsqlErrorLog(
+            connectionString: "Host=localhost;Database=test;",
+            createTablesIfNotExist: false);
+
+        act.Should().NotThrow();
+    }
+}

--- a/Tests/ElmahCore.Tests/SqlErrorLogTests.cs
+++ b/Tests/ElmahCore.Tests/SqlErrorLogTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+using ElmahCore.Sql;
+
+namespace ElmahCore.Tests;
+
+public class SqlErrorLogTests
+{
+    [Fact]
+    public void SqlErrorLog_WithOptions_LogAllXmlTrue_DoesNotThrow()
+    {
+        var options = Substitute.For<IOptions<ElmahOptions>>();
+        options.Value.Returns(new ElmahOptions
+        {
+            ConnectionString = "Server=localhost;Database=test;",
+            LogAllXml = true,
+            CreateTablesIfNotExist = false
+        });
+
+        var act = () => new SqlErrorLog(options);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void SqlErrorLog_WithOptions_LogAllXmlFalse_DoesNotThrow()
+    {
+        var options = Substitute.For<IOptions<ElmahOptions>>();
+        options.Value.Returns(new ElmahOptions
+        {
+            ConnectionString = "Server=localhost;Database=test;",
+            LogAllXml = false,
+            CreateTablesIfNotExist = false
+        });
+
+        var act = () => new SqlErrorLog(options);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void SqlErrorLog_Constructor_WithLogAllXmlParameter_DoesNotThrow()
+    {
+        var act = () => new SqlErrorLog(
+            connectionString: "Server=localhost;Database=test;",
+            schemaName: "dbo",
+            tableName: "ELMAH_Error",
+            createTablesIfNotExist: false,
+            logAllXml: false);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void SqlErrorLog_Constructor_LogAllXmlDefaultsToTrue()
+    {
+        // The constructor has logAllXml = true as the default parameter
+        var act = () => new SqlErrorLog(
+            connectionString: "Server=localhost;Database=test;",
+            createTablesIfNotExist: false);
+
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
Add LogAllXml boolean property to ElmahOptions that allows users to disable storing the full XML representation of errors in the database. When disabled, a minimal placeholder XML is stored instead, reducing storage requirements for high-volume applications.

Changes:
- Add LogAllXml property to ElmahOptions (default: true)
- Update SqlErrorLog, PgsqlErrorLog, MySqlErrorLog to respect the setting
- Add CreateTablesIfNotExist parameter to MySqlErrorLog for consistency
- Add ElmahCore.Tests project with unit tests for the new feature
- Update README.md with usage documentation

Resolves #6 