### PR TITLE
feat: Add optional statusCode parameter to RaiseError methods

### DIFF
--- a/ElmahCore.Mvc/ElmahExtensions.cs
+++ b/ElmahCore.Mvc/ElmahExtensions.cs
@@ -45,6 +45,21 @@ public static class ElmahExtensions
         return LogMiddleware.LogException(ex, ctx, (context, error) => Task.CompletedTask);
     }
 
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static Task RaiseError(this HttpContext ctx, Exception ex, int statusCode)
+    {
+        GuardForNullMiddleware();
+        return LogMiddleware.LogException(ex, ctx, (context, error) => Task.CompletedTask, statusCode: statusCode);
+    }
+
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static Task RaiseError(this HttpContext ctx, Exception ex, int statusCode,
+        Func<HttpContext, Error, Task> onError)
+    {
+        GuardForNullMiddleware();
+        return LogMiddleware.LogException(ex, ctx, onError, statusCode: statusCode);
+    }
+
     [Obsolete("Prefer RaiseError")]
     public static void RiseError(Exception ex)
     {
@@ -62,6 +77,19 @@ public static class ElmahExtensions
     public static void RaiseError(Exception ex)
     {
         RaiseError(ex, (context, error) => Task.CompletedTask);
+    }
+
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static void RaiseError(Exception ex, int statusCode)
+    {
+        RaiseError(ex, statusCode, (context, error) => Task.CompletedTask);
+    }
+
+    // ReSharper disable once MemberCanBePrivate.Global
+    public static void RaiseError(Exception ex, int statusCode, Func<HttpContext, Error, Task> onError)
+    {
+        LogMiddleware?.LogException(ex, InternalHttpContext.Current ?? new DefaultHttpContext(),
+            onError, statusCode: statusCode);
     }
 
     [UsedImplicitly]

--- a/ElmahCore.Mvc/ErrorLogMiddleware.cs
+++ b/ElmahCore.Mvc/ErrorLogMiddleware.cs
@@ -270,7 +270,7 @@ internal sealed class ErrorLogMiddleware
     }
 
     internal async Task<string> LogException(Exception e, HttpContext context,
-        Func<HttpContext, Error, Task> onError, string body = null)
+        Func<HttpContext, Error, Task> onError, string body = null, int? statusCode = null)
     {
         if (e == null)
             throw new ArgumentNullException(nameof(e));
@@ -297,6 +297,10 @@ internal sealed class ErrorLogMiddleware
             // AddMessage away...
             //
             var error = new Error(e, context, body);
+
+            // Override status code if provided
+            if (statusCode.HasValue)
+                error.StatusCode = statusCode.Value;
 
             await onError(context, error);
             error.ApplicationName = _errorLog.ApplicationName;

--- a/ElmahCore.Mvc/ErrorLogMiddleware.cs
+++ b/ElmahCore.Mvc/ErrorLogMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -272,8 +272,7 @@ internal sealed class ErrorLogMiddleware
     internal async Task<string> LogException(Exception e, HttpContext context,
         Func<HttpContext, Error, Task> onError, string body = null, int? statusCode = null)
     {
-        if (e == null)
-            throw new ArgumentNullException(nameof(e));
+        ArgumentNullException.ThrowIfNull(e);
 
         //
         // Fire an event to check if listeners want to filter out
@@ -285,7 +284,7 @@ internal sealed class ErrorLogMiddleware
         try
         {
             var args = new ExceptionFilterEventArgs(e, context);
-            if (_filters.Any())
+            if (_filters.Count != 0)
             {
                 OnFiltering(args);
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The interfaces and namespaces have been kept the same.
 
 # License
 
-This project is licensed under the terms of the Apache license 2.0.
+This project is licensed under the terms of the Apache License 2.0.
 
 # Warnings & Dragons
 
@@ -28,7 +28,7 @@ The source code for the front end appears non-existent, in ElmahCore the front e
 
 # Using ElmahCore
 
-ELMAH for Net.Standard 2.0 and .Net 6
+ELMAH for Net Core 10 
 
 Add NuGet package [ElmahCoreEx](https://www.nuget.org/packages?q=elmahcoreex)
 
@@ -66,11 +66,11 @@ app.UseAuthorization();
 //...
 app.UseElmah(); // needs to be positioned after `UseAuthentication` and `UseAuthorization`
 ```
-or the user will be redirected to the sign in screen even if they are authenticated.
+or the user will be redirected to the sign-in screen even if they are authenticated.
 
 ## Change Error Log type
 
-You can implement a custom error log adapter, to write logs to alternate locations.
+You can implement a custom error log adapter to write logs to alternate locations.
 
 ```csharp
 public class MyErrorLog: ErrorLog {
@@ -200,7 +200,7 @@ services.AddElmah<XmlFileErrorLog>(options =>
     options.Notifiers.Add(new ErrorMailNotifier("Email",emailOptions));
 });
 ```
-Each notifier must have unique name.
+Each notifier must have a unique name.
 
 ## Using Filters
 
@@ -237,5 +237,5 @@ see more [here](https://elmah.github.io/a/error-filtering/examples/)
 
 JavaScript filters have not been implemented
 
-Add notifiers to errorFilter node if you do not want to send notifications
-Filtered errors will be logged, but will not be sent.
+Attach notifiers to the errorFilter node if you wish to avoid sending notifications.
+Errors that are filtered will be recorded but not dispatched.

--- a/Tests/ElmahCore.Mvc.Tests/ErrorLogMiddlewareTests.cs
+++ b/Tests/ElmahCore.Mvc.Tests/ErrorLogMiddlewareTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using Options = Microsoft.Extensions.Options.Options;
 using Xunit;
 
 namespace ElmahCore.Mvc.Tests;
@@ -37,5 +38,72 @@ public class ErrorLogMiddlewareTests
         _ = new ErrorLogMiddleware(_requestDelegate, _errorLog, _loggerFactory, _options);
         var act = async () => await ElmahExtensions.RaiseError(new DefaultHttpContext(), new Exception());
         act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task LogExceptionWithStatusCodeOverridesDefault()
+    {
+        var errorLog = new MemoryErrorLog();
+        var options = Options.Create(new ElmahOptions());
+        var middleware = new ErrorLogMiddleware(_requestDelegate, errorLog, _loggerFactory, options);
+        var context = new DefaultHttpContext();
+
+        var id = await middleware.LogException(
+            new InvalidOperationException("Test"),
+            context,
+            (ctx, error) => Task.CompletedTask,
+            statusCode: 404);
+
+        id.Should().NotBeNullOrEmpty();
+        var entry = errorLog.GetError(id);
+        entry.Should().NotBeNull();
+        entry.Error.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public async Task LogExceptionWithStatusCodeAndCallbackOverridesDefault()
+    {
+        var errorLog = new MemoryErrorLog();
+        var options = Options.Create(new ElmahOptions());
+        var middleware = new ErrorLogMiddleware(_requestDelegate, errorLog, _loggerFactory, options);
+        var context = new DefaultHttpContext();
+        var callbackInvoked = false;
+
+        var id = await middleware.LogException(
+            new InvalidOperationException("Test"),
+            context,
+            (ctx, error) =>
+            {
+                callbackInvoked = true;
+                return Task.CompletedTask;
+            },
+            statusCode: 422);
+
+        id.Should().NotBeNullOrEmpty();
+        var entry = errorLog.GetError(id);
+        entry.Should().NotBeNull();
+        entry.Error.StatusCode.Should().Be(422);
+        callbackInvoked.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LogExceptionWithoutStatusCodeUsesErrorDefault()
+    {
+        var errorLog = new MemoryErrorLog();
+        var options = Options.Create(new ElmahOptions());
+        var middleware = new ErrorLogMiddleware(_requestDelegate, errorLog, _loggerFactory, options);
+        var context = new DefaultHttpContext();
+
+        var id = await middleware.LogException(
+            new InvalidOperationException("Test"),
+            context,
+            (ctx, error) => Task.CompletedTask);
+
+        id.Should().NotBeNullOrEmpty();
+        var entry = errorLog.GetError(id);
+        entry.Should().NotBeNull();
+        // With DefaultHttpContext (no connection), Error defaults to 0
+        // With a real HTTP context, it would default to 500
+        entry.Error.StatusCode.Should().Be(0);
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@ Migrate all projects to .NET 10, update dependencies and adjust solution structu
 
 - Migrate to net10
 - Update dependencies
+- Add `LogAllXml` option to disable full XML logging in database error logs
+- Add optional `statusCode` parameter to `RaiseError()` methods for custom HTTP status codes
 
 ## 2.1.4-beta 1
 


### PR DESCRIPTION
Add new overloads to RaiseError() that accept an optional statusCode parameter, allowing users to specify a custom HTTP status code when raising errors. Previously, all non-HttpException errors defaulted to status code 500.

New methods added:
- RaiseError(HttpContext, Exception, int statusCode)
- RaiseError(HttpContext, Exception, int statusCode, Func<...> onError)
- RaiseError(Exception, int statusCode)
- RaiseError(Exception, int statusCode, Func<...> onError)

Resolves #7 